### PR TITLE
Update references

### DIFF
--- a/docs/mvfits_paper/mvf.bib
+++ b/docs/mvfits_paper/mvf.bib
@@ -19,26 +19,22 @@
   title        = {llondon6/positive: charge},
   month        = "Aug",
   year         = "2018",
-  doi          = "10.5281/zenodo.1402516",
-  url          = {https://doi.org/10.5281/zenodo.1402516}
+  doi          = "10.5281/zenodo.1402516"
 }
 
 @article{Bohe:2016gbl,
-      author         = "Bohé, Alejandro and others",
-      title          = "{Improved effective-one-body model of spinning,
-                        nonprecessing binary black holes for the era of
-                        gravitational-wave astrophysics with advanced detectors}",
-      journal        = "Phys. Rev.",
-      volume         = "D95",
-      year           = "2017",
-      number         = "4",
-      pages          = "044028",
-      doi            = "10.1103/PhysRevD.95.044028",
-      eprint         = "1611.03703",
-      archivePrefix  = "arXiv",
-      primaryClass   = "gr-qc",
-      reportNumber   = "LIGO-P1600315",
-      SLACcitation   = "%%CITATION = ARXIV:1611.03703;%%"
+  title = {Improved effective-one-body model of spinning, nonprecessing binary black holes for the era of gravitational-wave astrophysics with advanced detectors},
+  author = {Boh\'e, Alejandro and Shao, Lijing and Taracchini, Andrea and Buonanno, Alessandra and Babak, Stanislav and Harry, Ian W. and Hinder, Ian and Ossokine, Serguei and P\"urrer, Michael and Raymond, Vivien and Chu, Tony and Fong, Heather and Kumar, Prayush and Pfeiffer, Harald P. and Boyle, Michael and Hemberger, Daniel A. and Kidder, Lawrence E. and Lovelace, Geoffrey and Scheel, Mark A. and Szil\'agyi, B\'ela},
+  journal = {Phys. Rev. D},
+  volume = {95},
+  issue = {4},
+  pages = {044028},
+  numpages = {29},
+  year = {2017},
+  month = {Feb},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevD.95.044028},
+  url = {https://link.aps.org/doi/10.1103/PhysRevD.95.044028}
 }
 
 @article{Buonanno:2000ef,
@@ -541,24 +537,6 @@ and
       SLACcitation   = "%%CITATION = ARXIV:1307.6232;%%"
 }
 
-@article{Bohe:2016gbl,
-      author         = "Bohé, Alejandro and others",
-      title          = "{Improved effective-one-body model of spinning,
-                        nonprecessing binary black holes for the era of
-                        gravitational-wave astrophysics with advanced detectors}",
-      journal        = "Phys. Rev.",
-      volume         = "D95",
-      year           = "2017",
-      number         = "4",
-      pages          = "044028",
-      doi            = "10.1103/PhysRevD.95.044028",
-      eprint         = "1611.03703",
-      archivePrefix  = "arXiv",
-      primaryClass   = "gr-qc",
-      reportNumber   = "LIGO-P1600315",
-      SLACcitation   = "%%CITATION = ARXIV:1611.03703;%%"
-}
-
 @article{Nagar:2018zoe,
       author         = "Nagar, Alessandro and others",
       title          = "{Time-domain effective-one-body gravitational waveforms
@@ -605,7 +583,26 @@ and
       year           = "2018",
       number         = "1",
       pages          = "3",
-      doi            = "10.1007/s41114-018-0012-9, 10.1007/lrr-2016-1",
+      doi            = "10.1007/s41114-018-0012-9",
+      eprint         = "1304.0670",
+      archivePrefix  = "arXiv",
+      primaryClass   = "gr-qc",
+      reportNumber   = "LIGO-P1200087, VIR-0288A-12",
+      SLACcitation   = "%%CITATION = ARXIV:1304.0670;%%"
+}
+
+@article{Abbott2018OS:2016,
+      author         = "Abbott, B. P. and others",
+      title          = "{Prospects for Observing and Localizing
+                        Gravitational-Wave Transients with Advanced LIGO, Advanced
+                        Virgo and KAGRA}",
+      collaboration  = "KAGRA, LIGO Scientific, VIRGO",
+      journal        = "Living Rev. Rel.",
+      volume         = "21",
+      year           = "2018",
+      number         = "1",
+      pages          = "3",
+      doi            = "10.1007/lrr-2016-1",
       eprint         = "1304.0670",
       archivePrefix  = "arXiv",
       primaryClass   = "gr-qc",

--- a/docs/mvfits_paper/mvf.bib
+++ b/docs/mvfits_paper/mvf.bib
@@ -725,3 +725,15 @@ and
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@InProceedings{Pandit84,
+  author = "Pandit, Vinay and Khairullah, Zahid Y.",
+  editor = "Malhotra, Naresh K.",
+  title = "Stepwise Regression Choosing the Proper Level of Significance",
+  booktitle = "Proceedings of the 1985 Academy of Marketing Science (AMS) Annual Conference",
+  year = "2015",
+  publisher = "Springer International Publishing",
+  address = "Cham",
+  pages = "395--398",
+  doi = "10.1007/978-3-319-16943-9_84",
+  isbn = "978-3-319-16943-9"
+}

--- a/docs/mvfits_paper/mvf.bib
+++ b/docs/mvfits_paper/mvf.bib
@@ -753,3 +753,21 @@ and
   url = {https://arxiv.org/abs/1811.12907},
   SLACcitation = "%%CITATION = ARXIV:1811.12907;%%"
 }
+
+@article{Mehta:2019wxm,
+      author         = "Mehta, Ajit Kumar and Tiwari, Praveer and
+                        Johnson-McDaniel, Nathan K. and Mishra, Chandra Kant and
+                        Varma, Vijay and Ajith, Parameswaran",
+      title          = "{Including Mode Mixing in a Higher-Multipole Model for
+                        Gravitational Waveforms from Nonspinning Black-Hole
+                        Binaries}",
+      year           = "2019",
+      eprint         = "1902.02731",
+      archivePrefix  = "arXiv",
+      primaryClass   = "gr-qc",
+      reportNumber   = "LIGO-P1800203-v6",
+      journal = "arXiv:1902.02731",
+      doi = "ARXIV:1902.02731",
+      url = {https://arxiv.org/abs/1902.02731},
+      SLACcitation   = "%%CITATION = ARXIV:1902.02731;%%"
+}

--- a/docs/mvfits_paper/mvf.bib
+++ b/docs/mvfits_paper/mvf.bib
@@ -653,6 +653,9 @@ and
       eprint         = "1809.10113",
       archivePrefix  = "arXiv",
       primaryClass   = "gr-qc",
+      journal        = "arXiv:1809.10113",
+      doi            = "ARXIV:1809.10113",
+      url            = {https://arxiv.org/abs/1809.10113},
       SLACcitation   = "%%CITATION = ARXIV:1809.10113;%%"
 }
 

--- a/docs/mvfits_paper/mvf.bib
+++ b/docs/mvfits_paper/mvf.bib
@@ -737,3 +737,19 @@ and
   doi = "10.1007/978-3-319-16943-9_84",
   isbn = "978-3-319-16943-9"
 }
+
+@article{LIGOScientific:2018mvr,
+  author = "Abbott, B. P. and others",
+  title = "{GWTC-1: A Gravitational-Wave Transient Catalog of Compact Binary Mergers Observed by LIGO and Virgo during the First and Second Observing Runs}",
+  collaboration = "LIGO Scientific, Virgo",
+  year = "2018",
+  eprint = "1811.12907",
+  eid = {arXiv:1811.12907},
+  archivePrefix = "arXiv",
+  primaryClass = "astro-ph.HE",
+  reportNumber = "LIGO-P1800307",
+  journal = "arXiv:1811.12907",
+  doi = "ARXIV:1811.12907",
+  url = {https://arxiv.org/abs/1811.12907},
+  SLACcitation = "%%CITATION = ARXIV:1811.12907;%%"
+}

--- a/docs/mvfits_paper/mvf.bib
+++ b/docs/mvfits_paper/mvf.bib
@@ -754,6 +754,23 @@ and
   SLACcitation = "%%CITATION = ARXIV:1811.12907;%%"
 }
 
+
+%PhysRevD.99.064045
+@article{Varma:2018mmi,
+  title = {Surrogate model of hybridized numerical relativity binary black hole waveforms},
+  author = {Varma, Vijay and Field, Scott E. and Scheel, Mark A. and Blackman, Jonathan and Kidder, Lawrence E. and Pfeiffer, Harald P.},
+  journal = {Phys. Rev. D},
+  volume = {99},
+  issue = {6},
+  pages = {064045},
+  numpages = {21},
+  year = {2019},
+  month = {Mar},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevD.99.064045},
+  url = {https://link.aps.org/doi/10.1103/PhysRevD.99.064045}
+}
+
 @article{Mehta:2019wxm,
       author         = "Mehta, Ajit Kumar and Tiwari, Praveer and
                         Johnson-McDaniel, Nathan K. and Mishra, Chandra Kant and

--- a/docs/mvfits_paper/mvf.bib
+++ b/docs/mvfits_paper/mvf.bib
@@ -329,10 +329,45 @@ and
       eprint         = "1510.08159",
       archivePrefix  = "arXiv",
       primaryClass   = "gr-qc",
+      journal        = "arXiv:1510.08159",
+      doi            = "ARXIV:1510.08159",
+      url            = {https://arxiv.org/abs/1510.08159},
       SLACcitation   = "%%CITATION = ARXIV:1510.08159;%%"
 }
 
 @article{Zimmerman:2015trm,
+  title = {Damped and zero-damped quasinormal modes of charged, nearly extremal black holes},
+  author = {Zimmerman, Aaron and Mark, Zachary},
+  journal = {Phys. Rev. D},
+  volume = {93},
+  issue = {4},
+  pages = {044033},
+  numpages = {23},
+  year = {2016},
+  month = {Feb},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevD.93.044033},
+  url = {https://link.aps.org/doi/10.1103/PhysRevD.93.044033},
+  related = {Zimmerman:2015trm:erratum},
+  relatedstring={Corrected in},
+}
+
+@article{Zimmerman:2015trm:erratum,
+  title = {Erratum: Damped and zero-damped quasinormal modes of charged, nearly extremal black holes [Phys. Rev. D 93, 044033 (2016)]},
+  author = {Zimmerman, Aaron and Mark, Zachary},
+  journal = {Phys. Rev. D},
+  volume = {93},
+  issue = {8},
+  pages = {089905},
+  numpages = {1},
+  year = {2016},
+  month = {Apr},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevD.93.089905},
+  url = {https://link.aps.org/doi/10.1103/PhysRevD.93.089905}
+}
+
+@article{Zimmerman:2015trm:arXiv,
       author         = "Zimmerman, Aaron and Mark, Zachary",
       title          = "{Damped and zero-damped quasinormal modes of charged,
                         nearly extremal black holes}",

--- a/docs/mvfits_paper/mvf.tex
+++ b/docs/mvfits_paper/mvf.tex
@@ -201,7 +201,7 @@ Whereas the calculation of each ${_{-2}S}\lmn$ involves a series solution which 
 It is therefore efficient to use accurate models for $\sigma\LMlmn$ to avoid convergence issues. These can then be used directly to calculate $h\LM$ via \eqn{hlm}, and thereby the \gw{} polarizations via \eqn{hrd}.
 %
 %
-\par In this combined context, it is clear that the modeling of \qnm{} frequencies, $\cw\lmn$, and spherical-spheroidal mixing coefficients, $\sigma\LMlmn$, are relevant for a range of \gw{} signal models.
+\par In this combined context, it is clear that the modeling of \qnm{} frequencies, $\cw\lmn$, and spherical-spheroidal mixing coefficients, $\sigma\LMlmn$, are relevant for a range of \gw{} signal models (e.g. \cite{Mehta:2019wxm}).
 %
 While models for $\cw\lmn$ and $\sigma\LMlmn$ are present in the literature (e.g. \cite{Berti:2005ys, Berti:2014fga, Cook:2014cta}), there exist minor shortcomings which we wish to address here.
 %

--- a/docs/mvfits_paper/mvf.tex
+++ b/docs/mvfits_paper/mvf.tex
@@ -103,7 +103,7 @@ superscriptaddress,10pt]{revtex4-1}
 
 \section{Introduction}
 %
-In the coming years, expectations for frequent \gw{} detections of increasing \snr{} are high \cite{TheLIGOScientific:2016pea,Abbott:2016nhf}.
+In the coming years, expectations for frequent \gw{} detections of increasing \snr{} are high \cite{TheLIGOScientific:2016pea,Abbott:2016nhf,LIGOScientific:2018mvr}.
 %
 Concurrent with \virgo{}, the \aligo{} detectors will enter their third observing run in approximately early 2019.
 %

--- a/docs/mvfits_paper/mvf.tex
+++ b/docs/mvfits_paper/mvf.tex
@@ -111,7 +111,7 @@ During this period, a few to dozens of \bbh{} signals are likely to be detected 
 %
 In this context, signal detection and subsequent inference of physical parameters hinges upon efficient models for source properties and dynamics \cite{Abbott:2016wiq}.
 %
-Most prominently, there is ongoing interest in efficient and accurate signal models for \bbh{} \imr{} \cite{Blackman:2017dfb, London:2017bcn, Hannam:2013oca}.
+Most prominently, there is ongoing interest in efficient and accurate signal models for \bbh{} \imr{} \cite{Blackman:2017dfb, London:2017bcn, Hannam:2013oca, Varma:2018mmi, Pan:2013rra, Cotesta:2018fcv}.
 %
 As the merger of isolated \bh{s} is expected to result in a perturbed Kerr \bh{}, there is related interest in having accurate and computationally efficient models for perturbative parameters, namely those that enable evaluation of the related \rd{} radiation \cite{Berti:2005ys,TheLIGOScientific:2016wfe}.
 %

--- a/docs/mvfits_paper/mvf.tex
+++ b/docs/mvfits_paper/mvf.tex
@@ -167,7 +167,7 @@ The consequences of that approximation, in particular the mixing between spheric
 This approximation also applies to the \textit{Phenom} models,
 where the frequency domain multipoles, $\tilde{h}\LM(f)$, are constructed such that their high frequency behavior is consistent with \eqn{hrd} in the time domain
 %
-\cite{Hannam:2013oca, London:2017bcn, Khan:2015jqa, Schmidt:2014iyl, Mehta:2017jpq,Khan:2018fmp}.
+\cite{Hannam:2013oca, London:2017bcn, Khan:2015jqa, Mehta:2017jpq,Khan:2018fmp}.
 %
 \par Both Phenom and \eob{} approaches either use phenomenological models of remnant \bh{} mass and spin to interpolate over tables of \qnm{} frequencies, or phenomenological models for \qnm{} frequencies are used directly.
 %

--- a/docs/mvfits_paper/mvf.tex
+++ b/docs/mvfits_paper/mvf.tex
@@ -850,7 +850,7 @@ In particular, it is shown that the two branches (namely $\jf>0$ and $\jf<0$) na
 %
 Concurrently, the use of $\kappa$ as a domain variable has the desirable effect of making each $\cw\lmn$ and $\tau\lmn$ approximately polynomial.
 %
-We note that, in the asymptotic vicinity of $\jf=1$, the \qnm{} frequencies and decay times are known to have solutions that are asymptoticly degenerate \cite{Zimmerman:2015rua}.
+We note that, in the asymptotic vicinity of $\jf=1$, the \qnm{} frequencies and decay times are known to have solutions that are asymptoticly degenerate \cite{Zimmerman:2015trm}.
 %
 {\scriptsize
 \begin{algorithm}[H]


### PR DESCRIPTION
(#17 should be merged first)

### Summary of changes

- **Updating bibtex entries to improve styling**  
  This including removing url's so that both DOI's hyperlinks and explicit urls were not redundantly rendered and non-latin character escapes. This also involved splitting bibtex entries when they had multiple DOI's associated with them so that we only reference a single (and the correct/intended) DOI.

- **Adding missing fields**  
  Some entries were missing fields, especially for pre-prints, these have been either updated with published bibtex entries or missing fields populated with `arXiv` information.

- **Updated text citations**  
  Some citations were added and removed from the text at the request of the referee.