### PR TITLE
Make backward compatible with Python 2.7

### DIFF
--- a/positive/physics.py
+++ b/positive/physics.py
@@ -1,4 +1,5 @@
 #
+from __future__ import print_function
 from positive import *
 from positive.plotting import *
 from positive.learning import *


### PR DESCRIPTION
Really simple fix to allow backward compatibility with Python 2.7 after the updated to ensure Python 3 compatibility.  This is equivalent to 

https://github.com/llondon6/positive/blob/1a46410834fd4eadb25fab5bf4c4d7f1892c2625/positive/io.py#L2

that was added in #2 and still maintains compatibility with Python 3 while making compatible with Python 2.7.